### PR TITLE
Disabled attr-new-line rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "gulp-html-bemlinter": "^2.1.4",
         "gulp-w3c-html-validator": "^5.3.0",
         "html-validate": "^8.5.0",
-        "linthtml-config-htmlacademy": "^1.0.12",
+        "linthtml-config-htmlacademy": "^1.0.13",
         "puppeteer": "^21.5.0",
         "stylelint": "^15.10.3",
         "stylelint-config-htmlacademy": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gulp-html-bemlinter": "^2.1.4",
     "gulp-w3c-html-validator": "^5.3.0",
     "html-validate": "^8.5.0",
-    "linthtml-config-htmlacademy": "^1.0.12",
+    "linthtml-config-htmlacademy": "^1.0.13",
     "puppeteer": "^21.5.0",
     "stylelint": "^15.10.3",
     "stylelint-config-htmlacademy": "^2.0.4",
@@ -42,8 +42,8 @@
     "source/sass/**/*.scss"
   ],
   "dependencies": {
-    "@babel/preset-env": "7.18.6",
     "@babel/core": "7.21.4",
+    "@babel/preset-env": "7.18.6",
     "autoprefixer": "^10.4.16",
     "babelify": "10.0.0",
     "browserify": "^17.0.0",


### PR DESCRIPTION
Обновление отрубает правило `attr-new-line`, которое заставляет переносить атрибуты на новую строку если их больше 6